### PR TITLE
Implement task reducers for create/update/delete/status flows

### DIFF
--- a/module/spacetimedb/src/schema.ts
+++ b/module/spacetimedb/src/schema.ts
@@ -75,4 +75,189 @@ const taskContexts = table(
   }
 );
 
-export default schema(users, tasks, taskLogs, projects, contexts, taskContexts);
+const db = schema(users, tasks, taskLogs, projects, contexts, taskContexts);
+
+const CLARIFY_STATUSES = new Set(["next", "waiting", "someday"]);
+
+function assertTaskOwner(ctx: any, taskId: bigint) {
+  const task = ctx.db.tasks.id.find(taskId);
+  if (!task) {
+    throw new Error("Task not found");
+  }
+
+  if (!task.userId.equals(ctx.sender)) {
+    throw new Error("Not authorized");
+  }
+
+  return task;
+}
+
+function logStatusChange(
+  ctx: any,
+  taskId: bigint,
+  previousStatus: string,
+  nextStatus: string
+) {
+  if (previousStatus === nextStatus) {
+    return;
+  }
+
+  ctx.db.taskLogs.insert({
+    taskId,
+    message: `Status changed from ${previousStatus} to ${nextStatus}`,
+    createdAt: ctx.timestamp,
+  });
+}
+
+db.reducer(
+  "create_task",
+  {
+    title: t.string(),
+    notes: t.string().optional(),
+    priority: t.string(),
+    dueDate: t.timestamp().optional(),
+    projectId: t.u64().optional(),
+    parentTaskId: t.u64().optional(),
+  },
+  (ctx, payload) => {
+    if (payload.projectId !== undefined) {
+      const project = ctx.db.projects.id.find(payload.projectId);
+      if (!project || !project.userId.equals(ctx.sender)) {
+        throw new Error("Project not found");
+      }
+    }
+
+    ctx.db.tasks.insert({
+      userId: ctx.sender,
+      title: payload.title,
+      notes: payload.notes,
+      status: "inbox",
+      priority: payload.priority,
+      projectId: payload.projectId,
+      dueDate: payload.dueDate,
+      parentTaskId: payload.parentTaskId,
+      createdAt: ctx.timestamp,
+      updatedAt: ctx.timestamp,
+    });
+  }
+);
+
+db.reducer(
+  "update_task",
+  {
+    taskId: t.u64(),
+    title: t.string().optional(),
+    notes: t.string().optional(),
+    priority: t.string().optional(),
+    dueDate: t.timestamp().optional(),
+  },
+  (ctx, { taskId, title, notes, priority, dueDate }) => {
+    const task = assertTaskOwner(ctx, taskId);
+
+    ctx.db.tasks.id.update({
+      ...task,
+      title: title ?? task.title,
+      notes: notes ?? task.notes,
+      priority: priority ?? task.priority,
+      dueDate: dueDate ?? task.dueDate,
+      updatedAt: ctx.timestamp,
+    });
+  }
+);
+
+db.reducer("delete_task", { taskId: t.u64() }, (ctx, { taskId }) => {
+  assertTaskOwner(ctx, taskId);
+
+  ctx.db.taskContexts.taskId.delete(taskId);
+  ctx.db.taskLogs.taskId.delete(taskId);
+  ctx.db.tasks.id.delete(taskId);
+});
+
+db.reducer("complete_task", { taskId: t.u64() }, (ctx, { taskId }) => {
+  const task = assertTaskOwner(ctx, taskId);
+  const nextStatus = "done";
+
+  ctx.db.tasks.id.update({
+    ...task,
+    status: nextStatus,
+    updatedAt: ctx.timestamp,
+  });
+
+  logStatusChange(ctx, taskId, task.status, nextStatus);
+});
+
+db.reducer("move_to_inbox", { taskId: t.u64() }, (ctx, { taskId }) => {
+  const task = assertTaskOwner(ctx, taskId);
+  const nextStatus = "inbox";
+
+  ctx.db.tasks.id.update({
+    ...task,
+    status: nextStatus,
+    updatedAt: ctx.timestamp,
+  });
+
+  logStatusChange(ctx, taskId, task.status, nextStatus);
+});
+
+db.reducer(
+  "clarify_task",
+  {
+    taskId: t.u64(),
+    status: t.string(),
+    projectId: t.u64().optional(),
+    contextIds: t.array(t.u64()),
+    priority: t.string(),
+  },
+  (ctx, { taskId, status, projectId, contextIds, priority }) => {
+    const task = assertTaskOwner(ctx, taskId);
+
+    if (!CLARIFY_STATUSES.has(status)) {
+      throw new Error("Invalid clarify status");
+    }
+
+    if (projectId !== undefined) {
+      const project = ctx.db.projects.id.find(projectId);
+      if (!project || !project.userId.equals(ctx.sender)) {
+        throw new Error("Project not found");
+      }
+    }
+
+    const uniqueContextIds = [...new Set(contextIds)];
+    for (const contextId of uniqueContextIds) {
+      const context = ctx.db.contexts.id.find(contextId);
+      if (!context || !context.userId.equals(ctx.sender)) {
+        throw new Error("Context not found");
+      }
+    }
+
+    ctx.db.taskContexts.taskId.delete(taskId);
+    for (const contextId of uniqueContextIds) {
+      ctx.db.taskContexts.insert({ taskId, contextId });
+    }
+
+    ctx.db.tasks.id.update({
+      ...task,
+      status,
+      projectId,
+      priority,
+      updatedAt: ctx.timestamp,
+    });
+
+    logStatusChange(ctx, taskId, task.status, status);
+  }
+);
+
+db.reducer("trash_task", { taskId: t.u64() }, (ctx, { taskId }) => {
+  const task = assertTaskOwner(ctx, taskId);
+  const nextStatus = "trash";
+
+  ctx.db.tasks.id.update({
+    ...task,
+    status: nextStatus,
+    updatedAt: ctx.timestamp,
+  });
+
+  logStatusChange(ctx, taskId, task.status, nextStatus);
+});
+
+export default db;


### PR DESCRIPTION
Task: 1

Implements task reducers with sender ownership validation and status-change logging:
- create_task (defaults status to inbox)
- update_task (title, notes, priority, dueDate)
- delete_task
- complete_task
- move_to_inbox
- clarify_task (project, contexts, priority, status next/waiting/someday)
- trash_task

Also cleans up related task_contexts/task_logs on delete_task.